### PR TITLE
Add function to include xUnit.NET tests

### DIFF
--- a/cmake/Modules/FindDotNETExtra.cmake
+++ b/cmake/Modules/FindDotNETExtra.cmake
@@ -78,8 +78,19 @@ function(add_dotnet_test _TARGET_NAME)
     ${_add_dotnet_test_INCLUDE_NUPKGS}
     INCLUDE_REFERENCES
     ${_add_dotnet_test_INCLUDE_REFERENCES}
-    TEST_DLL
-    1
+  )
+
+  if(CSBUILD_PROJECT_DIR)
+      set(CURRENT_TARGET_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/${CSBUILD_PROJECT_DIR}")
+  else()
+      set(CURRENT_TARGET_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+  endif()
+
+  ament_add_test(
+    ${name}_test
+    GENERATE_RESULT_FOR_RETURN_CODE_ZERO
+    WORKING_DIRECTORY ${CURRENT_TARGET_BINARY_DIR}/${_TARGET_NAME}
+    COMMAND dotnet test "${CURRENT_TARGET_BINARY_DIR}/${_TARGET_NAME}/${_TARGET_NAME}_${CSBUILD_CSPROJ}"
   )
 
 endfunction()

--- a/cmake/Modules/FindDotNETExtra.cmake
+++ b/cmake/Modules/FindDotNETExtra.cmake
@@ -78,7 +78,10 @@ function(add_dotnet_test _TARGET_NAME)
     ${_add_dotnet_test_INCLUDE_NUPKGS}
     INCLUDE_REFERENCES
     ${_add_dotnet_test_INCLUDE_REFERENCES}
+    TEST_DLL
+    1
   )
+
 endfunction()
 
 function(install_dotnet _TARGET_NAME)

--- a/cmake/Modules/FindDotNETExtra.cmake
+++ b/cmake/Modules/FindDotNETExtra.cmake
@@ -58,6 +58,29 @@ function(add_dotnet_executable _TARGET_NAME)
   )
 endfunction()
 
+function(add_dotnet_test _TARGET_NAME)
+  cmake_parse_arguments(_add_dotnet_test
+    ""
+    ""
+    "SOURCES;INCLUDE_DLLS;INCLUDE_NUPKGS;INCLUDE_REFERENCES"
+    ${ARGN}
+  )
+
+  set(CSHARP_TARGET_FRAMEWORK "netcoreapp2.0")
+  csharp_add_project(${_TARGET_NAME}
+    EXECUTABLE
+    SOURCES
+    ${_add_dotnet_test_SOURCES}
+    ${_add_dotnet_test_UNPARSED_ARGUMENTS}
+    INCLUDE_DLLS
+    ${_add_dotnet_test_INCLUDE_DLLS}
+    INCLUDE_NUPKGS
+    ${_add_dotnet_test_INCLUDE_NUPKGS}
+    INCLUDE_REFERENCES
+    ${_add_dotnet_test_INCLUDE_REFERENCES}
+  )
+endfunction()
+
 function(install_dotnet _TARGET_NAME)
     get_target_property(_target_executable ${_TARGET_NAME} EXECUTABLE)
     get_target_property(_target_path ${_TARGET_NAME} OUTPUT_PATH)

--- a/cmake/Modules/FindDotNETExtra.cmake
+++ b/cmake/Modules/FindDotNETExtra.cmake
@@ -67,6 +67,12 @@ function(add_dotnet_test _TARGET_NAME)
   )
 
   set(CSHARP_TARGET_FRAMEWORK "netcoreapp2.0")
+  set(XUNIT_INCLUDE_REFERENCES
+    "Microsoft.NET.Test.Sdk=15.9.0"
+    "xunit=2.4.1"
+    "xunit.runner.visualstudio=2.4.1"
+  )
+
   csharp_add_project(${_TARGET_NAME}
     EXECUTABLE
     SOURCES
@@ -78,6 +84,7 @@ function(add_dotnet_test _TARGET_NAME)
     ${_add_dotnet_test_INCLUDE_NUPKGS}
     INCLUDE_REFERENCES
     ${_add_dotnet_test_INCLUDE_REFERENCES}
+    ${XUNIT_INCLUDE_REFERENCES}
   )
 
   if(CSBUILD_PROJECT_DIR)

--- a/cmake/Modules/dotnet/Directory.Build.props
+++ b/cmake/Modules/dotnet/Directory.Build.props
@@ -1,5 +1,0 @@
-<Project>
-  <PropertyGroup Condition="$(MSBuildProjectName.Contains('dotnetcore'))">
-    <BaseIntermediateOutputPath>obj_core\</BaseIntermediateOutputPath>
-  </PropertyGroup>
-</Project>

--- a/cmake/Modules/dotnet/Directory.Build.props.in
+++ b/cmake/Modules/dotnet/Directory.Build.props.in
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup Condition="$(MSBuildProjectName.Contains('dotnetcore'))">
-    <BaseIntermediateOutputPath>@CSHARP_BUILDER_OUTPUT_NAME@_obj_core\</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath>@CSHARP_BUILDER_OUTPUT_NAME@\</BaseIntermediateOutputPath>
   </PropertyGroup>
 </Project>

--- a/cmake/Modules/dotnet/Directory.Build.props.in
+++ b/cmake/Modules/dotnet/Directory.Build.props.in
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup Condition="$(MSBuildProjectName.Contains('dotnetcore'))">
+    <BaseIntermediateOutputPath>@CSHARP_BUILDER_OUTPUT_NAME@_obj_core\</BaseIntermediateOutputPath>
+  </PropertyGroup>
+</Project>

--- a/cmake/Modules/dotnet/UseCSharpProjectBuilder.cmake
+++ b/cmake/Modules/dotnet/UseCSharpProjectBuilder.cmake
@@ -11,7 +11,7 @@ function(csharp_add_project name)
         set(CURRENT_TARGET_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
     endif()
     set(CSBUILD_PROJECT_DIR "")
-    file(MAKE_DIRECTORY ${CURRENT_TARGET_BINARY_DIR})
+    file(MAKE_DIRECTORY ${CURRENT_TARGET_BINARY_DIR}/${name})
     cmake_parse_arguments(_csharp_add_project
         "EXECUTABLE"
         ""
@@ -41,10 +41,10 @@ function(csharp_add_project name)
         list(GET PACKAGE_ID 1 PACKAGE_VERSION)
         list(APPEND packages "<PackageReference;Include=\\\"${PACKAGE_NAME}\\\";Version=\\\"${PACKAGE_VERSION}\\\";/>")
         list(APPEND legacy_packages "<package;id=\\\"${PACKAGE_NAME}\\\";version=\\\"${PACKAGE_VERSION}\\\";/>")
-        file(TO_NATIVE_PATH "${CURRENT_TARGET_BINARY_DIR}/${PACKAGE_NAME}.${PACKAGE_VERSION}/lib/**/*.dll" hint_path)
+        file(TO_NATIVE_PATH "${CURRENT_TARGET_BINARY_DIR}/${name}/${PACKAGE_NAME}.${PACKAGE_VERSION}/lib/**/*.dll" hint_path)
         list(APPEND refs "<Reference;Include=\\\"${hint_path}\\\";></Reference>")
 
-        file(TO_NATIVE_PATH "${CURRENT_TARGET_BINARY_DIR}/${PACKAGE_NAME}.${PACKAGE_VERSION}/build/${PACKAGE_NAME}.targets" target_path)
+        file(TO_NATIVE_PATH "${CURRENT_TARGET_BINARY_DIR}/${name}/${PACKAGE_NAME}.${PACKAGE_VERSION}/build/${PACKAGE_NAME}.targets" target_path)
         list(APPEND imports "<Import;Project=\\\"${target_path}\\\";Condition=\\\"Exists('${target_path}')\\\";/>")
     endforeach()
 
@@ -154,27 +154,27 @@ function(csharp_add_project name)
         -DMSBUILD_TOOLSET="${MSBUILD_TOOLSET}"
         -DCSHARP_IMPORTS="${CSHARP_IMPORTS}"
         -DCONFIG_INPUT_FILE="${CSBUILD_CSPROJ_IN}"
-        -DCONFIG_OUTPUT_FILE="${CURRENT_TARGET_BINARY_DIR}/${CSBUILD_${name}_CSPROJ}"
+        -DCONFIG_OUTPUT_FILE="${CURRENT_TARGET_BINARY_DIR}/${name}/${CSBUILD_${name}_CSPROJ}"
         -P ${dotnet_cmake_module_DIR}/ConfigureFile.cmake
 
         COMMAND ${CMAKE_COMMAND}
         -DCSHARP_PACKAGE_REFERENCES="${CSHARP_LEGACY_PACKAGE_REFERENCES}"
         -DCONFIG_INPUT_FILE="${dotnet_cmake_module_DIR}/Modules/dotnet/packages.config.in"
-        -DCONFIG_OUTPUT_FILE="${CURRENT_TARGET_BINARY_DIR}/packages.config"
+        -DCONFIG_OUTPUT_FILE="${CURRENT_TARGET_BINARY_DIR}/${name}/packages.config"
         -P ${dotnet_cmake_module_DIR}/ConfigureFile.cmake
 
         COMMAND ${CMAKE_COMMAND}
         -DCSHARP_BUILDER_OUTPUT_NAME="${name}${CSBUILD_OUTPUT_SUFFIX}"
         -DCONFIG_INPUT_FILE="${dotnet_cmake_module_DIR}/Modules/dotnet/Directory.Build.props.in"
-        -DCONFIG_OUTPUT_FILE="${CURRENT_TARGET_BINARY_DIR}/Directory.Build.props"
+        -DCONFIG_OUTPUT_FILE="${CURRENT_TARGET_BINARY_DIR}/${name}/${name}$/Directory.Build.props"
         -P ${dotnet_cmake_module_DIR}/ConfigureFile.cmake
 
         COMMAND ${RESTORE_CMD}
 
         COMMAND ${CSBUILD_EXECUTABLE} ${CSBUILD_RESTORE_FLAGS} ${CSBUILD_${name}_CSPROJ}
         COMMAND ${CSBUILD_EXECUTABLE} ${CSBUILD_BUILD_FLAGS} ${CSBUILD_${name}_CSPROJ}
-        WORKING_DIRECTORY ${CURRENT_TARGET_BINARY_DIR}
-        COMMENT "${RESTORE_CMD};${CSBUILD_EXECUTABLE} ${CSBUILD_RESTORE_FLAGS} ${CSBUILD_${name}_CSPROJ}; ${CSBUILD_EXECUTABLE} ${CSBUILD_BUILD_FLAGS} ${CSBUILD_${name}_CSPROJ} -> ${CURRENT_TARGET_BINARY_DIR}"
+        WORKING_DIRECTORY ${CURRENT_TARGET_BINARY_DIR}/${name}
+        COMMENT "${RESTORE_CMD};${CSBUILD_EXECUTABLE} ${CSBUILD_RESTORE_FLAGS} ${CSBUILD_${name}_CSPROJ}; ${CSBUILD_EXECUTABLE} ${CSBUILD_BUILD_FLAGS} ${CSBUILD_${name}_CSPROJ} -> ${CURRENT_TARGET_BINARY_DIR}/${name}"
         DEPENDS ${sources_dep}
     )
 
@@ -182,7 +182,7 @@ function(csharp_add_project name)
         ament_add_test(
           ${name}_test
           GENERATE_RESULT_FOR_RETURN_CODE_ZERO
-          COMMAND dotnet test "${CURRENT_TARGET_BINARY_DIR}/${CSBUILD_${name}_CSPROJ}"
+          COMMAND dotnet test "${CURRENT_TARGET_BINARY_DIR}/${name}/${CSBUILD_${name}_CSPROJ}"
         )
     endif()
 

--- a/cmake/Modules/dotnet/UseCSharpProjectBuilder.cmake
+++ b/cmake/Modules/dotnet/UseCSharpProjectBuilder.cmake
@@ -15,7 +15,7 @@ function(csharp_add_project name)
     cmake_parse_arguments(_csharp_add_project
         "EXECUTABLE"
         ""
-        "SOURCES;INCLUDE_DLLS;INCLUDE_NUPKGS;INCLUDE_REFERENCES"
+        "SOURCES;INCLUDE_DLLS;INCLUDE_NUPKGS;INCLUDE_REFERENCES;TEST_DLL"
         ${ARGN}
     )
 
@@ -164,7 +164,8 @@ function(csharp_add_project name)
         -P ${dotnet_cmake_module_DIR}/ConfigureFile.cmake
 
         COMMAND ${CMAKE_COMMAND}
-        -DCONFIG_INPUT_FILE="${dotnet_cmake_module_DIR}/Modules/dotnet/Directory.Build.props"
+        -DCSHARP_BUILDER_OUTPUT_NAME="${name}${CSBUILD_OUTPUT_SUFFIX}"
+        -DCONFIG_INPUT_FILE="${dotnet_cmake_module_DIR}/Modules/dotnet/Directory.Build.props.in"
         -DCONFIG_OUTPUT_FILE="${CURRENT_TARGET_BINARY_DIR}/Directory.Build.props"
         -P ${dotnet_cmake_module_DIR}/ConfigureFile.cmake
 
@@ -176,6 +177,14 @@ function(csharp_add_project name)
         COMMENT "${RESTORE_CMD};${CSBUILD_EXECUTABLE} ${CSBUILD_RESTORE_FLAGS} ${CSBUILD_${name}_CSPROJ}; ${CSBUILD_EXECUTABLE} ${CSBUILD_BUILD_FLAGS} ${CSBUILD_${name}_CSPROJ} -> ${CURRENT_TARGET_BINARY_DIR}"
         DEPENDS ${sources_dep}
     )
+
+    if (${_csharp_add_project_TEST_DLL})
+        ament_add_test(
+          ${name}_test
+          GENERATE_RESULT_FOR_RETURN_CODE_ZERO
+          COMMAND dotnet test "${CURRENT_TARGET_BINARY_DIR}/${CSBUILD_${name}_CSPROJ}"
+        )
+    endif()
 
     set(DOTNET_OUTPUT_PATH ${CSHARP_BUILDER_OUTPUT_PATH}/${CSHARP_TARGET_FRAMEWORK}/${DOTNET_CORE_RUNTIME}/publish/)
 

--- a/cmake/Modules/dotnet/UseCSharpProjectBuilder.cmake
+++ b/cmake/Modules/dotnet/UseCSharpProjectBuilder.cmake
@@ -166,7 +166,7 @@ function(csharp_add_project name)
         COMMAND ${CMAKE_COMMAND}
         -DCSHARP_BUILDER_OUTPUT_NAME="${name}${CSBUILD_OUTPUT_SUFFIX}"
         -DCONFIG_INPUT_FILE="${dotnet_cmake_module_DIR}/Modules/dotnet/Directory.Build.props.in"
-        -DCONFIG_OUTPUT_FILE="${CURRENT_TARGET_BINARY_DIR}/${name}/${name}$/Directory.Build.props"
+        -DCONFIG_OUTPUT_FILE="${CURRENT_TARGET_BINARY_DIR}/${name}/${name}/Directory.Build.props"
         -P ${dotnet_cmake_module_DIR}/ConfigureFile.cmake
 
         COMMAND ${RESTORE_CMD}

--- a/cmake/Modules/dotnet/UseCSharpProjectBuilder.cmake
+++ b/cmake/Modules/dotnet/UseCSharpProjectBuilder.cmake
@@ -166,7 +166,7 @@ function(csharp_add_project name)
         COMMAND ${CMAKE_COMMAND}
         -DCSHARP_BUILDER_OUTPUT_NAME="${name}${CSBUILD_OUTPUT_SUFFIX}"
         -DCONFIG_INPUT_FILE="${dotnet_cmake_module_DIR}/Modules/dotnet/Directory.Build.props.in"
-        -DCONFIG_OUTPUT_FILE="${CURRENT_TARGET_BINARY_DIR}/${name}/${name}/Directory.Build.props"
+        -DCONFIG_OUTPUT_FILE="${CURRENT_TARGET_BINARY_DIR}/${name}/Directory.Build.props"
         -P ${dotnet_cmake_module_DIR}/ConfigureFile.cmake
 
         COMMAND ${RESTORE_CMD}

--- a/cmake/Modules/dotnet/UseCSharpProjectBuilder.cmake
+++ b/cmake/Modules/dotnet/UseCSharpProjectBuilder.cmake
@@ -15,7 +15,7 @@ function(csharp_add_project name)
     cmake_parse_arguments(_csharp_add_project
         "EXECUTABLE"
         ""
-        "SOURCES;INCLUDE_DLLS;INCLUDE_NUPKGS;INCLUDE_REFERENCES;TEST_DLL"
+        "SOURCES;INCLUDE_DLLS;INCLUDE_NUPKGS;INCLUDE_REFERENCES"
         ${ARGN}
     )
 
@@ -177,14 +177,6 @@ function(csharp_add_project name)
         COMMENT "${RESTORE_CMD};${CSBUILD_EXECUTABLE} ${CSBUILD_RESTORE_FLAGS} ${CSBUILD_${name}_CSPROJ}; ${CSBUILD_EXECUTABLE} ${CSBUILD_BUILD_FLAGS} ${CSBUILD_${name}_CSPROJ} -> ${CURRENT_TARGET_BINARY_DIR}/${name}"
         DEPENDS ${sources_dep}
     )
-
-    if (${_csharp_add_project_TEST_DLL})
-        ament_add_test(
-          ${name}_test
-          GENERATE_RESULT_FOR_RETURN_CODE_ZERO
-          COMMAND dotnet test "${CURRENT_TARGET_BINARY_DIR}/${name}/${CSBUILD_${name}_CSPROJ}"
-        )
-    endif()
 
     set(DOTNET_OUTPUT_PATH ${CSHARP_BUILDER_OUTPUT_PATH}/${CSHARP_TARGET_FRAMEWORK}/${DOTNET_CORE_RUNTIME}/publish/)
 


### PR DESCRIPTION
Hi @esteve 

PR esteve/ros2_dotnet#10 contributes to the opportunity of performing xUnit tests. Furthermore, each project could require a different .NET standard, as happens with xUnit.

In order to include more than one C# project in a single ros2 package, it is necessary to do some changes in this repo/package. The proposed changes let to build individually several C# projects in the same package. 

Best