### PR TITLE
Add new options for `install_dotnet()`

### DIFF
--- a/cmake/Modules/FindDotNETExtra.cmake
+++ b/cmake/Modules/FindDotNETExtra.cmake
@@ -118,7 +118,7 @@ function(install_dotnet _TARGET_NAME)
     else()
       cmake_parse_arguments(_install_dotnet
         "CD_TO_EXECUTABLE"
-        "DESTINATION"
+        "DESTINATION;ENTRY_POINT_NAME"
         ""
         ${ARGN})
       if (_install_dotnet_DESTINATION)
@@ -130,23 +130,29 @@ function(install_dotnet _TARGET_NAME)
     install(DIRECTORY ${_target_path}/ DESTINATION ${_DESTINATION})
 
     if(_target_executable)
+      if (_install_dotnet_ENTRY_POINT_NAME)
+        set(_ENTRY_POINT_NAME ${_install_dotnet_ENTRY_POINT_NAME})
+      else()
+        # default to _TARGET_NAME
+        set(_ENTRY_POINT_NAME ${_TARGET_NAME})
+      endif()
       set(DOTNET_DLL_PATH ${_target_name})
       if(WIN32)
         if (_install_dotnet_CD_TO_EXECUTABLE)
-          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point_with_cd.windows.in lib/${_TARGET_NAME}.bat @ONLY)
+          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point_with_cd.windows.in lib/${_ENTRY_POINT_NAME}.bat @ONLY)
         else()
-          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point.windows.in lib/${_TARGET_NAME}.bat @ONLY)
+          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point.windows.in lib/${_ENTRY_POINT_NAME}.bat @ONLY)
         endif()
-        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/${_TARGET_NAME}.bat
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/${_ENTRY_POINT_NAME}.bat
           DESTINATION
           lib/${PROJECT_NAME})
       else()
         if (_install_dotnet_CD_TO_EXECUTABLE)
-          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point_with_cd.unix.in lib/${_TARGET_NAME} @ONLY)
+          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point_with_cd.unix.in lib/${_ENTRY_POINT_NAME} @ONLY)
         else()
-          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point.unix.in lib/${_TARGET_NAME} @ONLY)
+          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point.unix.in lib/${_ENTRY_POINT_NAME} @ONLY)
         endif()
-        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/${_TARGET_NAME}
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/${_ENTRY_POINT_NAME}
           DESTINATION
           lib/${PROJECT_NAME}
           PERMISSIONS

--- a/cmake/Modules/FindDotNETExtra.cmake
+++ b/cmake/Modules/FindDotNETExtra.cmake
@@ -117,7 +117,7 @@ function(install_dotnet _TARGET_NAME)
       set (_DESTINATION ${ARGV1})
     else()
       cmake_parse_arguments(_install_dotnet
-        ""
+        "CD_TO_EXECUTABLE"
         "DESTINATION"
         ""
         ${ARGN})
@@ -132,12 +132,20 @@ function(install_dotnet _TARGET_NAME)
     if(_target_executable)
       set(DOTNET_DLL_PATH ${_target_name})
       if(WIN32)
-        configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point.windows.in lib/${_TARGET_NAME}.bat @ONLY)
+        if (_install_dotnet_CD_TO_EXECUTABLE)
+          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point_with_cd.windows.in lib/${_TARGET_NAME}.bat @ONLY)
+        else()
+          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point.windows.in lib/${_TARGET_NAME}.bat @ONLY)
+        endif()
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/${_TARGET_NAME}.bat
           DESTINATION
           lib/${PROJECT_NAME})
       else()
-        configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point.unix.in lib/${_TARGET_NAME} @ONLY)
+        if (_install_dotnet_CD_TO_EXECUTABLE)
+          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point_with_cd.unix.in lib/${_TARGET_NAME} @ONLY)
+        else()
+          configure_file(${dotnet_cmake_module_DIR}/Modules/dotnet/entry_point.unix.in lib/${_TARGET_NAME} @ONLY)
+        endif()
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/${_TARGET_NAME}
           DESTINATION
           lib/${PROJECT_NAME}

--- a/cmake/Modules/dotnet/entry_point.unix.in
+++ b/cmake/Modules/dotnet/entry_point.unix.in
@@ -2,4 +2,4 @@
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd -P)"
 
-dotnet ${SCRIPTDIR}/dotnet/@DOTNET_DLL_PATH@
+dotnet ${SCRIPTDIR}/dotnet/@DOTNET_DLL_PATH@ "$@"

--- a/cmake/Modules/dotnet/entry_point.windows.in
+++ b/cmake/Modules/dotnet/entry_point.windows.in
@@ -1,1 +1,1 @@
-dotnet %~f0\dotnet\@DOTNET_DLL_PATH@
+dotnet %~f0\dotnet\@DOTNET_DLL_PATH@ %*

--- a/cmake/Modules/dotnet/entry_point_with_cd.unix.in
+++ b/cmake/Modules/dotnet/entry_point_with_cd.unix.in
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd -P)"
+
+cd ${SCRIPTDIR}/dotnet/
+dotnet ${SCRIPTDIR}/dotnet/@DOTNET_DLL_PATH@ "$@"

--- a/cmake/Modules/dotnet/entry_point_with_cd.windows.in
+++ b/cmake/Modules/dotnet/entry_point_with_cd.windows.in
@@ -1,0 +1,2 @@
+cd /D %~f0\dotnet\
+dotnet %~f0\dotnet\@DOTNET_DLL_PATH@ %*


### PR DESCRIPTION
This is the first part of our internal branch on `dotnet_cmake_module` we would like to upstream.
See here if youre interested in what's comming next:
- https://github.com/schiller-de/dotnet_cmake_module/pull/1
- https://github.com/schiller-de/dotnet_cmake_module/commits/feature-include-csproj

# Forward commandline arguments to dotnet executables

```
ros2 run some_dotnet_package some_dotnet_executable "Forwarding commandline arguments now works"
```

# CD_TO_EXECUTABLE

This option changes the entry point script to change the working directory to the directory of the dotnet executable dll. This is usefull for ASP.NET projets as they expect the resources relative to `pwd`.

# ENTRY_POINT_NAME

This option changes the name of the entry point script. This is the name which `ros2 run` uses to start the executable.

Example:
```cmake
...
# this function will be part of an upcomming PR
add_dotnet_executable_project(RosBlazorExample
  PROJ
  src/RosBlazorExample/RosBlazorExample.csproj
  INCLUDE_DLLS
  ${_assemblies_dep_dlls}
)

install_dotnet(RosBlazorExample
  CD_TO_EXECUTABLE
  ENTRY_POINT_NAME
  ros_blazor_example
  DESTINATION
  lib/${PROJECT_NAME}/dotnet
)
...
```
