### PR TITLE
Add argument for target framework in tests

### DIFF
--- a/cmake/Modules/FindDotNETExtra.cmake
+++ b/cmake/Modules/FindDotNETExtra.cmake
@@ -61,12 +61,17 @@ endfunction()
 function(add_dotnet_test _TARGET_NAME)
   cmake_parse_arguments(_add_dotnet_test
     ""
-    ""
+    "TARGET_FRAMEWORK"
     "SOURCES;INCLUDE_DLLS;INCLUDE_NUPKGS;INCLUDE_REFERENCES"
     ${ARGN}
   )
 
-  set(CSHARP_TARGET_FRAMEWORK "netcoreapp2.0")
+  if(_add_dotnet_test_TARGET_FRAMEWORK)
+    set(CSHARP_TARGET_FRAMEWORK ${_add_dotnet_test_TARGET_FRAMEWORK})
+  else()
+    set(CSHARP_TARGET_FRAMEWORK "netcoreapp2.0")
+  endif()
+
   set(XUNIT_INCLUDE_REFERENCES
     "Microsoft.NET.Test.Sdk=15.9.0"
     "xunit=2.4.1"

--- a/cmake/Modules/FindDotNETExtra.cmake
+++ b/cmake/Modules/FindDotNETExtra.cmake
@@ -69,7 +69,7 @@ function(add_dotnet_test _TARGET_NAME)
   if(_add_dotnet_test_TARGET_FRAMEWORK)
     set(CSHARP_TARGET_FRAMEWORK ${_add_dotnet_test_TARGET_FRAMEWORK})
   else()
-    set(CSHARP_TARGET_FRAMEWORK "netcoreapp2.0")
+    set(CSHARP_TARGET_FRAMEWORK "net6.0")
   endif()
 
   set(XUNIT_INCLUDE_REFERENCES


### PR DESCRIPTION
This allows to pass the TARGET_FRAMEWORK for tests explicitly to `add_dotnet_test()`.

used by https://github.com/ros2-dotnet/ros2_dotnet/pull/98

```cmake
add_dotnet_test(test_messages
  TARGET_FRAMEWORK "net6"
  SOURCES
  ${CS_SOURCES}
  # ...
)
```
